### PR TITLE
Typo fix

### DIFF
--- a/GlassCatalogIo.cpp
+++ b/GlassCatalogIo.cpp
@@ -7,7 +7,7 @@
 #include <cassert>
 using namespace std;
 
-#include "GlassCatalogIO.h"
+#include "GlassCatalogIo.h"
 #include "GlassSellmeier.h"
 #include "GlassManager.h"
 


### PR DESCRIPTION
GlassCatalogIo.h needs to have a lower case 'o' so GlassCatalogIo.cpp can compile